### PR TITLE
Use modules, not cogs

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import os, argparse, logging
 import discord
 from discord.ext import commands
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-t", "--token", metavar='TOKEN', help="Bot token. Keep this secret")

--- a/main.py
+++ b/main.py
@@ -26,6 +26,6 @@ async def unload(ctx, extension):
 
 bot.load_extension("utils.updater")
 bot.load_extension("utils.events")
-bot.load_extension("utils.leaderboardt")
+bot.load_extension("utils.leaderboard")
 
 bot.run(token)

--- a/main.py
+++ b/main.py
@@ -12,7 +12,6 @@ token, prefix = args.token, args.prefix
 
 intents = discord.Intents(messages=True, guilds=True, members=True)
 bot = commands.Bot(command_prefix=prefix, intents=intents)
-await bot.change_presence(activity=discord.Game(name=f"{prefix}help for info"))
 
 @bot.command
 async def load(ctx, extension):

--- a/main.py
+++ b/main.py
@@ -24,9 +24,8 @@ async def unload(ctx, extension):
 	bot.unload_extension(f"utils.{extension}")
 
 
-for filename in os.listdir("./utils"):
-	if filename.endswith(".py"):
-		bot.load_extension(f"utils.{filename[:-3]}")
-
+bot.load_extension("updater")
+bot.load_extension("events")
+bot.load_extension("leaderboard")
 
 bot.run(token)

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import os, argparse, logging
 import discord
 from discord.ext import commands
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.DEBUG)
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-t", "--token", metavar='TOKEN', help="Bot token. Keep this secret")

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ token, prefix = args.token, args.prefix
 
 intents = discord.Intents(messages=True, guilds=True, members=True)
 bot = commands.Bot(command_prefix=prefix, intents=intents)
-bot.change_presence(activity=discord.Game(name=f"{prefix}help for info"))
+await bot.change_presence(activity=discord.Game(name=f"{prefix}help for info"))
 
 @bot.command
 async def load(ctx, extension):
@@ -24,8 +24,8 @@ async def unload(ctx, extension):
 	bot.unload_extension(f"utils.{extension}")
 
 
-bot.load_extension("updater")
-bot.load_extension("events")
-bot.load_extension("leaderboard")
+bot.load_extension("utils.updater")
+bot.load_extension("utils.events")
+bot.load_extension("utils.leaderboardt")
 
 bot.run(token)

--- a/utils/converter.py
+++ b/utils/converter.py
@@ -1,10 +1,10 @@
 # Converts a timedelta object into seconds
-def delta_to_secs(self, delta):
+def delta_to_secs(delta):
 	return delta.days * 86400 + delta.seconds
 
 
 # Converts a number of seconds into a tuple consisting of hours, minutes, and seconds
-def secs_to_hms(self, seconds):
+def secs_to_hms(seconds):
 	hours, remainder = divmod(seconds, 3600)
 	minutes, seconds = divmod(remainder, 60)
 	return hours, minutes, seconds

--- a/utils/converter.py
+++ b/utils/converter.py
@@ -1,22 +1,10 @@
-from discord.ext import commands
-
-# Timedelta converters
-class Converter(commands.Cog):
-	def __init__(self, bot):
-		self.bot = bot
+# Converts a timedelta object into seconds
+def delta_to_secs(self, delta):
+	return delta.days * 86400 + delta.seconds
 
 
-	# Converts a timedelta object into seconds
-	def delta_to_secs(self, delta):
-		return delta.days * 86400 + delta.seconds
-
-
-	# Converts a number of seconds into a tuple consisting of hours, minutes, and seconds
-	def secs_to_hms(self, seconds):
-		hours, remainder = divmod(seconds, 3600)
-		minutes, seconds = divmod(remainder, 60)
-		return hours, minutes, seconds
-
-
-def setup(bot):
-    bot.add_cog(Converter(bot))
+# Converts a number of seconds into a tuple consisting of hours, minutes, and seconds
+def secs_to_hms(self, seconds):
+	hours, remainder = divmod(seconds, 3600)
+	minutes, seconds = divmod(remainder, 60)
+	return hours, minutes, seconds

--- a/utils/database.py
+++ b/utils/database.py
@@ -1,71 +1,61 @@
 import sqlite3
-from discord.ext import commands
 
 conn = sqlite3.connect("necromancy.db")
 c = conn.cursor()
 
-class Database(commands.Cog):
-	def __init__(self, bot):
-		self.bot = bot
+def commit():
+	conn.commit()
 
 
-	def commit(self):
-		conn.commit()
+# Adds or updates channel_id and guild_id in the guilds table
+def update_server(guild_id, channel_id):
+	c.execute("INSERT OR REPLACE INTO guilds (guild_id, channel_id, last_author_id, last_timestamp) VALUES (?, ?, ?, ?)", [guild_id, channel_id, None, None])
 
 
-	# Adds or updates channel_id and guild_id in the guilds table
-	def update_server(self, guild_id, channel_id):
-		c.execute("INSERT OR REPLACE INTO guilds (guild_id, channel_id, last_author_id, last_timestamp) VALUES (?, ?, ?, ?)", [guild_id, channel_id, None, None])
+# Updates the last message in a game channel
+def update_last_message(guild_id, author_id, timestamp):
+	c.execute("UPDATE guilds SET last_author_id = ?, last_timestamp = ? WHERE guild_id = ?", [author_id, timestamp, guild_id])
 
 
-	# Updates the last message in a game channel
-	def update_last_message(self, guild_id, author_id, timestamp):
-		c.execute("UPDATE guilds SET last_author_id = ?, last_timestamp = ? WHERE guild_id = ?", [author_id, timestamp, guild_id])
+# Adds or updates the score in the scores table
+def update_score(guild_id, user_id, score):
+	c.execute("INSERT OR REPLACE INTO scores (guild_id, user_id, score) VALUES (?, ?, ?)", [guild_id, user_id, score])
 
 
-	# Adds or updates the score in the scores table
-	def update_score(self, guild_id, user_id, score):
-		c.execute("INSERT OR REPLACE INTO scores (guild_id, user_id, score) VALUES (?, ?, ?)", [guild_id, user_id, score])
+# Clears an entire guild's score
+def clear_score(guild_id):
+	c.execute("DELETE FROM scores WHERE guild_id = ?", [guild_id])
 
 
-	# Clears an entire guild's score
-	def clear_score(self, guild_id):
-		c.execute("DELETE FROM scores WHERE guild_id = ?", [guild_id])
+# Retrieves the current guild's game channel's ID
+def retrieve_channel(guild_id):
+	try:
+		return c.execute("SELECT channel_id FROM guilds WHERE guild_id = ?", [guild_id]).fetchone()[0]
+	except TypeError:
+		return None
 
 
-	# Retrieves the current guild's game channel's ID
-	def retrieve_channel(self, guild_id):
-		try:
-			return c.execute("SELECT channel_id FROM guilds WHERE guild_id = ?", [guild_id]).fetchone()[0]
-		except TypeError:
-			return None
+# Retrieves the last message in a channel
+def retrieve_last_message(guild_id):
+	try:
+		return c.execute("SELECT last_author_id, last_timestamp FROM guilds WHERE guild_id = ?", [guild_id]).fetchone()
+	except TypeError:
+		return None
 
 
-	# Retrieves the last message in a channel
-	def retrieve_last_message(self, guild_id):
-		try:
-			return c.execute("SELECT last_author_id, last_timestamp FROM guilds WHERE guild_id = ?", [guild_id]).fetchone()
-		except TypeError:
-			return None
+# Retrieves the current user's score in the guild
+def retrieve_score(guild_id, user_id):
+	try:
+		return c.execute("SELECT score FROM scores WHERE guild_id = ? AND user_id = ?", [guild_id, user_id]).fetchone()[0]
+	except TypeError:
+		return 0
 
 
-	# Retrieves the current user's score in the guild
-	def retrieve_score(self, guild_id, user_id):
-		try:
-			return c.execute("SELECT score FROM scores WHERE guild_id = ? AND user_id = ?", [guild_id, user_id]).fetchone()[0]
-		except TypeError:
-			return 0
+# Retrieves the top 10 players in the guild
+def retrieve_top_ten(guild_id):
+	return c.execute("SELECT user_id, score FROM scores where guild_id = ? ORDER BY score DESC, user_id DESC LIMIT 10", [guild_id])
 
 
-	# Retrieves the top 10 players in the guild
-	def retrieve_top_ten(self, guild_id):
-		return c.execute("SELECT user_id, score FROM scores where guild_id = ? ORDER BY score DESC, user_id DESC LIMIT 10", [guild_id])
-
-
-	# Retrieves all players' scores in the guild
-	def retrieve_guild_scores(self, guild_id):
-		return c.execute("SELECT score FROM scores where guild_id = ? ORDER BY score DESC, user_id DESC", [guild_id])
-
-
-def setup(bot):
-    bot.add_cog(Database(bot))
+# Retrieves all players' scores in the guild
+def retrieve_guild_scores(guild_id):
+	return c.execute("SELECT score FROM scores where guild_id = ? ORDER BY score DESC, user_id DESC", [guild_id])

--- a/utils/events.py
+++ b/utils/events.py
@@ -9,7 +9,7 @@ class Events(commands.Cog):
 	@commands.Cog.listener()
 	async def on_ready(self):
 		print("We have logged in")
-		await bot.change_presence(activity=discord.Game(name=f"{prefix}help for info"))
+		await self.bot.change_presence(activity=discord.Game(name=f"{prefix}help for info"))
 
 
 def setup(bot):

--- a/utils/events.py
+++ b/utils/events.py
@@ -1,3 +1,4 @@
+import discord
 from discord.ext import commands
 
 class Events(commands.Cog):

--- a/utils/events.py
+++ b/utils/events.py
@@ -1,4 +1,5 @@
 import discord
+import main
 from discord.ext import commands
 
 class Events(commands.Cog):
@@ -10,7 +11,7 @@ class Events(commands.Cog):
 	@commands.Cog.listener()
 	async def on_ready(self):
 		print("We have logged in")
-		await self.bot.change_presence(activity=discord.Game(name=f"{prefix}help for info"))
+		await self.bot.change_presence(activity=discord.Game(name=f"{main.prefix}help for info"))
 
 
 def setup(bot):

--- a/utils/events.py
+++ b/utils/events.py
@@ -9,6 +9,7 @@ class Events(commands.Cog):
 	@commands.Cog.listener()
 	async def on_ready(self):
 		print("We have logged in")
+		await bot.change_presence(activity=discord.Game(name=f"{prefix}help for info"))
 
 
 def setup(bot):

--- a/utils/leaderboard.py
+++ b/utils/leaderboard.py
@@ -1,7 +1,9 @@
 from datetime import datetime, timezone
-import discord, utils.database, utils.converter
+import discord
 from discord.ext import commands
 from num2words import num2words
+import utils.database as database
+import utils.converter as converter
 
 class Leaderboard(commands.Cog):
 	def __init__(self, bot):

--- a/utils/leaderboard.py
+++ b/utils/leaderboard.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-import discord, database, converter
+import discord, utils.database, utils.converter
 from discord.ext import commands
 from num2words import num2words
 

--- a/utils/leaderboard.py
+++ b/utils/leaderboard.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-import discord
+import discord, database, converter
 from discord.ext import commands
 from num2words import num2words
 
@@ -17,7 +17,6 @@ class Leaderboard(commands.Cog):
 	)
 	async def leaderboard(self, ctx, *args):
 		guild, author = ctx.guild, ctx.author
-		database, converter = self.bot.get_cog("Database"), self.bot.get_cog("Converter")
 		try:
 			if len(args) == 0:
 				guild_scores = list(database.retrieve_guild_scores(guild.id))
@@ -44,6 +43,10 @@ class Leaderboard(commands.Cog):
 		except TypeError:
 			await ctx.send("Nobody has played yet!")
 
+	@leaderboard.error
+	async def update_error(self, ctx, error):
+		if isinstance(error, commands.BadArgument):
+			await ctx.send("Incorrect argument!")
 
 def setup(bot):
 	bot.add_cog(Leaderboard(bot))

--- a/utils/leaderboard.py
+++ b/utils/leaderboard.py
@@ -29,6 +29,7 @@ class Leaderboard(commands.Cog):
 					value=f"{hms_score[0]:02}:{hms_score[1]:02}:{hms_score[2]:02}"
 				)
 			elif len(args) == 1:
+				top10 = list(database.retrieve_top_ten(guild.id))
 				upto, i = int(args[0]), 0
 				leaderboard_embed = discord.Embed(title=f"Server rank for {guild.name}", timestamp=datetime.now(timezone.utc), color=discord.Colour(0x100000))
 				while i < upto:

--- a/utils/updater.py
+++ b/utils/updater.py
@@ -98,14 +98,17 @@ class Updater(commands.Cog):
 				print(i)
 				i += 1
 				if previous_author != current_author:
+					print("logic 1")
 					previous_timestamp, current_timestamp = current_timestamp, message.created_at
 					score_delta = current_timestamp - previous_timestamp
 					score_increase = converter.delta_to_secs(score_delta)
 					score = score_increase + database.retrieve_score(guild.id, current_author)
 					if current_author != self.bot.user.id:
+						print("logic 2a")
 						database.update_score(guild.id, current_author, score)
 						database.update_last_message(guild.id, current_author, current_timestamp.strftime("%Y-%m-%d %H:%M:%S"))
 					else:
+						print("logic 2b")
 						database.update_last_message(guild.id, 0, current_timestamp.strftime("%Y-%m-%d %H:%M:%S"))
 					
 		database.commit()

--- a/utils/updater.py
+++ b/utils/updater.py
@@ -84,10 +84,9 @@ class Updater(commands.Cog):
 		channel = guild.get_channel(database.retrieve_channel(guild.id))
 		first = True
 		database.clear_score(guild.id)
-		print("database cleared")
+		print(f"channel: {channel.name}")
 		async for message in channel.history(limit=None, oldest_first=True):
 			if first:
-				print("first message cleared")
 				current_timestamp = message.created_at
 				current_author = message.author.id
 				first = False

--- a/utils/updater.py
+++ b/utils/updater.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-import discord
+import discord, database, converter
 from discord.ext import commands
 
 class Updater(commands.Cog):
@@ -23,7 +23,6 @@ class Updater(commands.Cog):
 	@commands.Cog.listener()
 	async def on_message(self, message):
 		if message.author != self.bot.user:
-			database, converter = self.bot.get_cog("Database"), self.bot.get_cog("Converter")
 			guild, author, created_at = message.guild, message.author, message.created_at
 			channel = guild.get_channel(database.retrieve_channel(guild.id))
 			if channel != None and channel == message.channel:
@@ -43,7 +42,6 @@ class Updater(commands.Cog):
 
 	@commands.Cog.listener()
 	async def on_message_delete(self, message):
-		database = self.bot.get_cog("Database")
 		guild, author, created_at = message.guild, message.author, message.created_at
 		channel = guild.get_channel(database.retrieve_channel(guild.id))
 		if channel != None and channel == message.channel:
@@ -58,7 +56,6 @@ class Updater(commands.Cog):
 	)
 	@is_admin()
 	async def setchannel(self, ctx, channel: discord.TextChannel):
-		database = self.bot.get_cog("Database")
 		database.update_server(ctx.guild.id, channel.id)
 		database.commit()
 		await ctx.send(f"Successfully set <#{channel.id}> as the necromancy channel for this server.")
@@ -81,7 +78,6 @@ class Updater(commands.Cog):
 	@is_admin()
 	async def update(self, ctx):
 		guild = ctx.guild
-		database, converter = self.bot.get_cog("Database"), self.bot.get_cog("Converter")
 		channel = guild.get_channel(database.retrieve_channel(guild.id))
 		first = True
 		database.clear_score(guild.id)

--- a/utils/updater.py
+++ b/utils/updater.py
@@ -103,6 +103,7 @@ class Updater(commands.Cog):
 					print("logic 1.1")
 					score_delta = current_timestamp - previous_timestamp
 					print("logic 1.2")
+					print(score_delta)
 					score_increase = converter.delta_to_secs(score_delta)
 					print(score_increase)
 					print("logic 1.3")

--- a/utils/updater.py
+++ b/utils/updater.py
@@ -85,6 +85,7 @@ class Updater(commands.Cog):
 		first = True
 		database.clear_score(guild.id)
 		print(f"channel: {channel.name}")
+		i = 0
 		async for message in channel.history(limit=None, oldest_first=True):
 			if first:
 				current_timestamp = message.created_at
@@ -94,6 +95,8 @@ class Updater(commands.Cog):
 				database.update_last_message(guild.id, current_author, current_timestamp.strftime("%Y-%m-%d %H:%M:%S"))
 			else:
 				previous_author, current_author = current_author, message.author.id
+				print(i)
+				i += 1
 				if previous_author != current_author:
 					previous_timestamp, current_timestamp = current_timestamp, message.created_at
 					score_delta = current_timestamp - previous_timestamp
@@ -104,7 +107,7 @@ class Updater(commands.Cog):
 						database.update_last_message(guild.id, current_author, current_timestamp.strftime("%Y-%m-%d %H:%M:%S"))
 					else:
 						database.update_last_message(guild.id, 0, current_timestamp.strftime("%Y-%m-%d %H:%M:%S"))
-			
+					
 		database.commit()
 		await ctx.send("Successfully updated the channel.")
 		logging.info(f'[{datetime.now()}] UPDATE on server: {guild.id}')

--- a/utils/updater.py
+++ b/utils/updater.py
@@ -104,6 +104,7 @@ class Updater(commands.Cog):
 					score_delta = current_timestamp - previous_timestamp
 					print("logic 1.2")
 					score_increase = converter.delta_to_secs(score_delta)
+					print(score_increase)
 					print("logic 1.3")
 					score = score_increase + database.retrieve_score(guild.id, current_author)
 					print("logic 1.4")

--- a/utils/updater.py
+++ b/utils/updater.py
@@ -127,6 +127,8 @@ class Updater(commands.Cog):
 			await ctx.send("This guild does not have a game channel!")
 		elif isinstance(error, commands.CheckFailure):
 			await ctx.send("You do not have permissions to execute this command!")
+		else:
+			await ctx.send(error)
 
 def setup(bot):
 	bot.add_cog(Updater(bot))

--- a/utils/updater.py
+++ b/utils/updater.py
@@ -1,9 +1,9 @@
 import logging
 from datetime import datetime
 import discord
+from discord.ext import commands
 import utils.database as database
 import utils.converter as converter
-from discord.ext import commands
 
 class Updater(commands.Cog):
 	def __init__(self, bot):

--- a/utils/updater.py
+++ b/utils/updater.py
@@ -1,6 +1,8 @@
 import logging
 from datetime import datetime
-import discord, utils.database, utils.converter
+import discord
+import utils.database as database
+import utils.converter as converter
 from discord.ext import commands
 
 class Updater(commands.Cog):

--- a/utils/updater.py
+++ b/utils/updater.py
@@ -69,6 +69,8 @@ class Updater(commands.Cog):
 			await ctx.send("Please specify a proper channel!")
 		elif isinstance(error, commands.CheckFailure):
 			await ctx.send("You do not have permissions to execute this command!")
+		else:
+			print(error)
 
 
 	# Forces the leaderboard to update
@@ -84,8 +86,6 @@ class Updater(commands.Cog):
 		channel = guild.get_channel(database.retrieve_channel(guild.id))
 		first = True
 		database.clear_score(guild.id)
-		print(f"channel: {channel.name}")
-		i = 0
 		async for message in channel.history(limit=None, oldest_first=True):
 			if first:
 				current_timestamp = message.created_at
@@ -95,26 +95,15 @@ class Updater(commands.Cog):
 				database.update_last_message(guild.id, current_author, current_timestamp.strftime("%Y-%m-%d %H:%M:%S"))
 			else:
 				previous_author, current_author = current_author, message.author.id
-				print(i)
-				i += 1
 				if previous_author != current_author:
-					print("logic 1")
 					previous_timestamp, current_timestamp = current_timestamp, message.created_at
-					print("logic 1.1")
 					score_delta = current_timestamp - previous_timestamp
-					print("logic 1.2")
-					print(score_delta)
 					score_increase = converter.delta_to_secs(score_delta)
-					print(score_increase)
-					print("logic 1.3")
 					score = score_increase + database.retrieve_score(guild.id, current_author)
-					print("logic 1.4")
 					if current_author != self.bot.user.id:
-						print("logic 2a")
 						database.update_score(guild.id, current_author, score)
 						database.update_last_message(guild.id, current_author, current_timestamp.strftime("%Y-%m-%d %H:%M:%S"))
 					else:
-						print("logic 2b")
 						database.update_last_message(guild.id, 0, current_timestamp.strftime("%Y-%m-%d %H:%M:%S"))
 					
 		database.commit()
@@ -128,7 +117,7 @@ class Updater(commands.Cog):
 		elif isinstance(error, commands.CheckFailure):
 			await ctx.send("You do not have permissions to execute this command!")
 		else:
-			await ctx.send(error)
+			print(error)
 
 def setup(bot):
 	bot.add_cog(Updater(bot))

--- a/utils/updater.py
+++ b/utils/updater.py
@@ -79,12 +79,15 @@ class Updater(commands.Cog):
 	)
 	@is_admin()
 	async def update(self, ctx):
+		print("command invoked")
 		guild = ctx.guild
 		channel = guild.get_channel(database.retrieve_channel(guild.id))
 		first = True
 		database.clear_score(guild.id)
+		print("database cleared")
 		async for message in channel.history(limit=None, oldest_first=True):
 			if first:
+				print("first message cleared")
 				current_timestamp = message.created_at
 				current_author = message.author.id
 				first = False

--- a/utils/updater.py
+++ b/utils/updater.py
@@ -100,9 +100,13 @@ class Updater(commands.Cog):
 				if previous_author != current_author:
 					print("logic 1")
 					previous_timestamp, current_timestamp = current_timestamp, message.created_at
+					print("logic 1.1")
 					score_delta = current_timestamp - previous_timestamp
+					print("logic 1.2")
 					score_increase = converter.delta_to_secs(score_delta)
+					print("logic 1.3")
 					score = score_increase + database.retrieve_score(guild.id, current_author)
+					print("logic 1.4")
 					if current_author != self.bot.user.id:
 						print("logic 2a")
 						database.update_score(guild.id, current_author, score)

--- a/utils/updater.py
+++ b/utils/updater.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-import discord, database, converter
+import discord, utils.database, utils.converter
 from discord.ext import commands
 
 class Updater(commands.Cog):


### PR DESCRIPTION
**Why?**
Trust me, it removes a lot of the unnecessary `get_cog` methods, and this way, it's much more easier to edit

**What's changed?**

- Modified utils/database.py and utils/converter.py so that they are no longer cogs
- Modified utils/updater.py and utils/leaderboard.py so that they import database.py and converter.py as modules
- Modified main.py to not import databse.py and converter.py as a cog